### PR TITLE
Update better-sqlite3 to 7.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "async": "^3.2.0",
-    "better-sqlite3": "7.4.4",
+    "better-sqlite3": "7.5.0",
     "bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git"
   },
   "engine": {


### PR DESCRIPTION
This PR updates the `better-sqlite3` dep to `7.5.0`
The main reason is to avoid building a sqlite3 binary file on the `npm install` step in a `Docker` container based on the `alpine`
The binary build takes more time and requires more performance, it will be great to skip it step using a pre-built binary from the remote repo
This `7.5.0` release contains the required `better-sqlite3-v7.5.0-node-v93-linuxmusl-x64.tar.gz` pre-built binary https://github.com/JoshuaWise/better-sqlite3/releases/tag/v7.5.0