### PR TITLE
Bump deps to fix vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
   },
   "dependencies": {
     "async": "^3.2.0",
-    "better-sqlite3": "7.5.0",
+    "better-sqlite3": "8.0.1",
     "bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git"
   },
   "engine": {
-    "node": ">=12.16.0"
+    "node": ">=14.16.0"
   },
   "license": "Apache-2.0",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "async": "3.2.4",
-    "better-sqlite3": "8.0.1",
+    "better-sqlite3": "7.6.2",
     "bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git"
   },
   "engine": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "standard --env mocha"
   },
   "dependencies": {
-    "async": "^3.2.0",
+    "async": "3.2.4",
     "better-sqlite3": "8.0.1",
     "bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git"
   },
@@ -32,7 +32,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "chai-fs": "^2.0.0",
-    "mocha": "^8.1.3",
-    "standard": "^14.3.4"
+    "mocha": "^10.1.0",
+    "standard": "^17.0.0"
   }
 }


### PR DESCRIPTION
This PR bumps dependency versions to fix vulnerabilities.
Updates `better-sqlite3` from `7.5.0` to `7.6.2` to have the last changes/fixes of the [DB driver](https://github.com/WiseLibs/better-sqlite3/releases)
The main reason is to have updated `SQLite3` from `3.37.2` to `3.39.1`
Changelog:
  - https://sqlite.org/releaselog/3_38_5.html
  - https://www.sqlite.org/releaselog/3_39_1.html