### PR TITLE
Bump better-sqlite3 version up to 8.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "async": "3.2.4",
-    "better-sqlite3": "7.6.2",
+    "better-sqlite3": "8.3.0",
     "bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git"
   },
   "engine": {

--- a/test/base-worker.spec.js
+++ b/test/base-worker.spec.js
@@ -5,13 +5,13 @@ chai.use(require('chai-fs'))
 const { assert } = chai
 const path = require('path')
 const {
-  rmdirSync,
   mkdirSync
 } = require('fs')
 
 const {
   getTableCreationQuery,
-  getTableDeletionQuery
+  getTableDeletionQuery,
+  rmRfSync
 } = require('./helpers')
 
 const DB_WORKER_ACTIONS = require(
@@ -39,17 +39,17 @@ const tableData = [
 
 describe('Base worker', () => {
   before(() => {
-    rmdirSync(dbPathAbsolute, { recursive: true })
+    rmRfSync(dbPathAbsolute)
     mkdirSync(dbPathAbsolute, { recursive: true })
   })
 
   after(() => {
-    rmdirSync(dbPathAbsolute, { recursive: true })
+    rmRfSync(dbPathAbsolute)
   })
 
   describe('Setup step', () => {
     beforeEach(() => {
-      rmdirSync(dbPathAbsolute, { recursive: true })
+      rmRfSync(dbPathAbsolute)
       mkdirSync(dbPathAbsolute, { recursive: true })
     })
 
@@ -134,7 +134,7 @@ describe('Base worker', () => {
     let fac
 
     before((done) => {
-      rmdirSync(dbPathAbsolute, { recursive: true })
+      rmRfSync(dbPathAbsolute)
       mkdirSync(dbPathAbsolute, { recursive: true })
 
       fac = new Fac(caller, { dbPathAbsolute })

--- a/test/extended-worker.spec.js
+++ b/test/extended-worker.spec.js
@@ -3,13 +3,13 @@
 const { assert } = require('chai')
 const path = require('path')
 const {
-  rmdirSync,
   mkdirSync
 } = require('fs')
 
 const {
   getTableCreationQuery,
-  getTableDeletionQuery
+  getTableDeletionQuery,
+  rmRfSync
 } = require('./helpers')
 
 const BASE_DB_WORKER_ACTIONS = require(
@@ -42,12 +42,12 @@ const tableData = [
 
 describe('Extended worker', () => {
   before(() => {
-    rmdirSync(dbPathAbsolute, { recursive: true })
+    rmRfSync(dbPathAbsolute)
     mkdirSync(dbPathAbsolute, { recursive: true })
   })
 
   after(() => {
-    rmdirSync(dbPathAbsolute, { recursive: true })
+    rmRfSync(dbPathAbsolute)
   })
 
   it('Setup step', (done) => {

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -2,8 +2,10 @@
 
 const getTableCreationQuery = require('./get-table-creation-query')
 const getTableDeletionQuery = require('./get-table-deletion-query')
+const { rmRfSync } = require('./utils')
 
 module.exports = {
   getTableCreationQuery,
-  getTableDeletionQuery
+  getTableDeletionQuery,
+  rmRfSync
 }

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const fs = require('fs')
+
+const rmRfSync = (path) => fs.rmSync(path, {
+  recursive: true,
+  force: true
+})
+
+module.exports = {
+  rmRfSync
+}

--- a/test/load-extended-worker.spec.js
+++ b/test/load-extended-worker.spec.js
@@ -3,14 +3,14 @@
 const { assert } = require('chai')
 const path = require('path')
 const {
-  rmdirSync,
   mkdirSync
 } = require('fs')
 const { promisify } = require('util')
 
 const {
   getTableCreationQuery,
-  getTableDeletionQuery
+  getTableDeletionQuery,
+  rmRfSync
 } = require('./helpers')
 
 const BASE_DB_WORKER_ACTIONS = require(
@@ -38,7 +38,7 @@ describe('Load extended worker', () => {
   let fac
 
   before(async () => {
-    rmdirSync(dbPathAbsolute, { recursive: true })
+    rmRfSync(dbPathAbsolute)
     mkdirSync(dbPathAbsolute, { recursive: true })
 
     fac = new Fac(
@@ -55,7 +55,7 @@ describe('Load extended worker', () => {
 
   after((done) => {
     fac.stop(() => {
-      rmdirSync(dbPathAbsolute, { recursive: true })
+      rmRfSync(dbPathAbsolute)
       done()
     })
   })

--- a/test/sync-queries.spec.js
+++ b/test/sync-queries.spec.js
@@ -3,13 +3,13 @@
 const { assert } = require('chai')
 const path = require('path')
 const {
-  rmdirSync,
   mkdirSync
 } = require('fs')
 
 const {
   getTableCreationQuery,
-  getTableDeletionQuery
+  getTableDeletionQuery,
+  rmRfSync
 } = require('./helpers')
 
 const DB_WORKER_ACTIONS = require(
@@ -37,12 +37,12 @@ const tableData = [
 
 describe('Sync queries', () => {
   before(() => {
-    rmdirSync(dbPathAbsolute, { recursive: true })
+    rmRfSync(dbPathAbsolute)
     mkdirSync(dbPathAbsolute, { recursive: true })
   })
 
   after(() => {
-    rmdirSync(dbPathAbsolute, { recursive: true })
+    rmRfSync(dbPathAbsolute)
   })
 
   it('Setup step', (done) => {


### PR DESCRIPTION
This PR bumps `better-sqlite3` version up to `8.3.0` to be able to launch bfx-reports-framework under nodejs v16, resolves deprecation warning `fs.rmdir` due to migration nodejs to v16