### PR TITLE
Bump better-sqlite3 up to 8.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "async": "3.2.4",
-    "better-sqlite3": "8.3.0",
+    "better-sqlite3": "8.6.0",
     "bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git"
   },
   "engine": {


### PR DESCRIPTION
This PR bumps `better-sqlite3` up to `8.6.0` to have the ability to launch the db driver on Nodejs `v18` under electron env at least `v25`
And also to have this fix `random "database is locked" timeouts` https://github.com/WiseLibs/better-sqlite3/issues/597