### PR TITLE
Bump better-sqlite3 up to 9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "async": "3.2.4",
-    "better-sqlite3": "8.6.0",
+    "better-sqlite3": "9.0.0",
     "bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git"
   },
   "engine": {


### PR DESCRIPTION
This PR bumps `better-sqlite3` up to `9.0.0` to have the ability to launch the DB driver on Nodejs `v18.17.1` under electron env at least `v27`  (to have Nodejs version similar to UI build requirements)

- https://github.com/WiseLibs/better-sqlite3/releases/tag/v9.0.0
- https://releases.electronjs.org/release/v27.0.2
