### PR TITLE
Add test runner and report to GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+run-name: 'Run tests: Commit ${{ github.sha }}'
+
+on:
+  pull_request:
+    types: [opened, reopened, edited]
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  linux-test-runner:
+    name: Linux Test Runner
+    timeout-minutes: 30
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18.17.1
+    - name: Install deps
+      run: npm i
+    - name: Run tests
+      run: npm test -- -- --reporter=json --reporter-option output=test-report.json
+    - uses: actions/upload-artifact@v3
+      if: success() || failure()
+      with:
+        name: test-results
+        path: test-report.json

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,30 @@
+name: 'Test Report'
+run-name: 'Test Report: Commit ${{ github.sha }}'
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  web-page-report:
+    name: Web Page Report
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: dorny/test-reporter@v1
+      id: test-results
+      with:
+        artifact: test-results
+        name: Mocha Tests
+        path: test-report.json
+        reporter: mocha-json
+    - name: Test Report Summary
+      run: |
+        echo "### Test Report page is ready! :rocket:" >> $GITHUB_STEP_SUMMARY
+        echo "And available at the following [Link](${{ steps.test-results.outputs.url_html }})" >> $GITHUB_STEP_SUMMARY

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git"
   },
   "engine": {
-    "node": ">=14.16.0"
+    "node": ">=18.17.1"
   },
   "license": "Apache-2.0",
   "contributors": [
@@ -34,5 +34,15 @@
     "chai-fs": "^2.0.0",
     "mocha": "^10.1.0",
     "standard": "^17.0.0"
+  },
+  "standard": {
+    "globals": [
+      "describe",
+      "it",
+      "before",
+      "after",
+      "beforeEach",
+      "afterEach"
+    ]
   }
 }


### PR DESCRIPTION
This PR adds test runner and report workflows to GitHub actions

---

The test report will be similar to the bfx-reports-framework repo implementation https://github.com/bitfinexcom/bfx-reports-framework/pull/325
