### PR TITLE
Update gh actions to use nodejs v20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     types: [opened, reopened, edited]
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 jobs:
@@ -25,7 +25,7 @@ jobs:
       run: npm i
     - name: Run tests
       run: npm test -- -- --reporter=json --reporter-option output=test-report.json
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
         name: test-results

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -17,13 +17,22 @@ jobs:
     name: Web Page Report
     runs-on: ubuntu-22.04
     steps:
+    - name: Download test results
+      uses: actions/download-artifact@v4
+      with:
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        name: test-results
+        path: test-results
     - uses: dorny/test-reporter@v1
       id: test-results
       with:
-        artifact: test-results
         name: Mocha Tests
-        path: test-report.json
+        path: test-results/test-report.json
         reporter: mocha-json
+        # Workaround for error 'fatal: not a git repository' caused by a call to 'git ls-files'
+        # See: https://github.com/dorny/test-reporter/issues/169#issuecomment-1583560458
+        max-annotations: 0
     - name: Test Report Summary
       run: |
         echo "### Test Report page is ready! :rocket:" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,5 +1,5 @@
-name: 'Test Report'
-run-name: 'Test Report: Commit ${{ github.sha }}'
+name: 'Report of Test runs'
+run-name: 'Report of Test runs: Commit ${{ github.sha }}'
 
 on:
   workflow_run:
@@ -33,7 +33,7 @@ jobs:
         # Workaround for error 'fatal: not a git repository' caused by a call to 'git ls-files'
         # See: https://github.com/dorny/test-reporter/issues/169#issuecomment-1583560458
         max-annotations: 0
-    - name: Test Report Summary
+    - name: Summary
       run: |
         echo "### Test Report page is ready! :rocket:" >> $GITHUB_STEP_SUMMARY
         echo "And available at the following [Link](${{ steps.test-results.outputs.url_html }})" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This PR updates GH Actions to use Nodejs v20

---

Solution:
- as `dorny/test-reporter` GH Action is stuck with the update to support `actions/upload-artifact@v4`
- turns off downloading test results managed `dorny/test-reporter` with removing `artifact` options
- adds additional downloading step before `dorny/test-reporter` using `actions/download-artifact@v4` actions
- and use `actions/upload-artifact@v4` everywhere

---

**Notes:**
- after opening PR against `master` the unit tests will be triggered, but `Test Report` will fail because the GH Actions don't want to take the last incoming changes of the corresponding workflow file and uses already existing changes in the master branch that are incompatible. And after merging in the next release iteration, everything should work as expected
- the first release launch
![Screenshot from 2024-03-13 08-25-46](https://github.com/bitfinexcom/bfx-report-electron/assets/16489235/f4a107eb-121f-46cd-892d-d38333edb0ac)
- the next release launch
![Screenshot from 2024-03-13 08-26-44](https://github.com/bitfinexcom/bfx-report-electron/assets/16489235/d0dd11c7-b1bb-45da-9d0a-3d103b88491d)