### PR TITLE
Update better-sqlite3 version up to 11.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "async": "3.2.4",
-    "better-sqlite3": "9.0.0",
+    "better-sqlite3": "11.7.0",
     "bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git"
   },
   "engine": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "async": "3.2.4",
-    "better-sqlite3": "11.7.0",
+    "better-sqlite3": "11.7.2",
     "bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git"
   },
   "engine": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-facs-db-better-sqlite",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Bitfinex DB Sqlite3 Facility",
   "author": {
     "name": "Vladimir Voronkov",


### PR DESCRIPTION
This PR updates `better-sqlite3` version up to `11.7.2` to have the last binary rebuild and be able to launch the driver under electron `v33`
