### PR TITLE
Update better-sqlite3 version up to 12.4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         submodules: recursive
     - uses: actions/setup-node@v4
       with:
-        node-version: 20.18.1
+        node-version: 22.19.0
     - name: Install deps
       run: npm i
     - name: Run tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bfx-facs-db-better-sqlite",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bfx-facs-db-better-sqlite",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "async": "3.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "async": "3.2.4",
-        "better-sqlite3": "11.7.2",
+        "better-sqlite3": "12.4.1",
         "bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git"
       },
       "devDependencies": {
@@ -612,14 +612,17 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "11.7.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.7.2.tgz",
-      "integrity": "sha512-10a57cHVDmfNQS4jrZ9AH2t+2ekzYh5Rhbcnb4ytpmYweoLdogDmyTt5D+hLiY9b44Mx9foowb/4iXBTO2yP3Q==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.4.1.tgz",
+      "integrity": "sha512-3yVdyZhklTiNrtg+4WqHpJpFDd+WHTg2oM7UcR80GqL05AOV0xEJzc6qNvFYoEtE+hRp1n9MpN6/+4yhlGkDXQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x"
       }
     },
     "node_modules/bfx-facs-base": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git"
   },
   "engine": {
-    "node": ">=18.17.1"
+    "node": ">=20.18.1"
   },
   "license": "Apache-2.0",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-facs-db-better-sqlite",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Bitfinex DB Sqlite3 Facility",
   "author": {
     "name": "Vladimir Voronkov",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "async": "3.2.4",
-    "better-sqlite3": "11.7.2",
+    "better-sqlite3": "12.4.1",
     "bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git"
   },
   "engine": {


### PR DESCRIPTION
This PR updates `better-sqlite3` version up to `12.4.1` to have the last binary rebuild and be able to launch the driver under electron `v38`